### PR TITLE
feat: Add Odoo 19+ support with X-Odoo-Database header

### DIFF
--- a/src/zenoo_rpc/client.py
+++ b/src/zenoo_rpc/client.py
@@ -262,8 +262,10 @@ class ZenooClient:
             else:
                 params["args"].append({"context": call_context})
 
-        # Make the RPC call
-        result = await self._transport.json_rpc_call("object", "execute_kw", params)
+        # Make the RPC call (with database header for Odoo 19+)
+        result = await self._transport.json_rpc_call(
+            "object", "execute_kw", params, database=self._session.database
+        )
         return result.get("result")
 
     async def execute(

--- a/src/zenoo_rpc/models/base.py
+++ b/src/zenoo_rpc/models/base.py
@@ -5,7 +5,9 @@ This module provides the foundation for type-safe Odoo record handling
 using Pydantic models with ORM-like capabilities.
 """
 
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, ClassVar
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional, Set, Type, TypeVar, Union, ClassVar
 from datetime import date, datetime
 from pydantic import BaseModel, Field, ConfigDict, model_validator, field_validator
 from pydantic.fields import FieldInfo
@@ -126,7 +128,7 @@ class OdooModel(BaseModel, metaclass=OdooModelMeta):
     # Model metadata (excluded from serialization)
     odoo_name: ClassVar[str] = ""
     client: Optional[Any] = Field(default=None, exclude=True, repr=False)
-    loaded_fields: set[str] = Field(default_factory=set, exclude=True, repr=False)
+    loaded_fields: Set[str] = Field(default_factory=set, exclude=True, repr=False)
     relationship_manager: Optional[RelationshipManager] = Field(
         default=None, exclude=True, repr=False
     )
@@ -267,7 +269,7 @@ class OdooModel(BaseModel, metaclass=OdooModelMeta):
         """
         return field_name in self.loaded_fields
 
-    def get_loaded_fields(self) -> set[str]:
+    def get_loaded_fields(self) -> Set[str]:
         """Get the set of fields that have been loaded.
 
         Returns:

--- a/src/zenoo_rpc/query/builder.py
+++ b/src/zenoo_rpc/query/builder.py
@@ -5,11 +5,12 @@ This module provides a chainable, type-safe query interface for building
 and executing Odoo queries with performance optimization and lazy loading.
 """
 
+from __future__ import annotations
+
 import asyncio
 import hashlib
 import json
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, AsyncIterator
-from collections.abc import AsyncIterable
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, AsyncIterator, AsyncIterable
 
 from ..models.base import OdooModel
 from ..models.registry import get_model_class, get_registry

--- a/src/zenoo_rpc/query/lazy.py
+++ b/src/zenoo_rpc/query/lazy.py
@@ -5,9 +5,10 @@ This module provides lazy loading capabilities for efficient data fetching,
 including lazy collections and deferred loading strategies.
 """
 
+from __future__ import annotations
+
 import asyncio
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, AsyncIterator
-from collections.abc import AsyncIterable
+from typing import Any, Dict, List, Optional, Type, TypeVar, Union, AsyncIterator, AsyncIterable
 from weakref import WeakKeyDictionary
 
 T = TypeVar("T")

--- a/src/zenoo_rpc/transport/httpx_transport.py
+++ b/src/zenoo_rpc/transport/httpx_transport.py
@@ -73,6 +73,7 @@ class AsyncTransport:
         method: str,
         params: Dict[str, Any],
         request_id: Optional[str] = None,
+        database: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Make an async JSON-RPC call to the Odoo server.
 
@@ -81,6 +82,7 @@ class AsyncTransport:
             method: The method to call (e.g., "version", "execute_kw")
             params: Parameters to pass to the method
             request_id: Optional request ID for tracking
+            database: Optional database name to include in X-Odoo-Database header
 
         Returns:
             The JSON-RPC response data
@@ -106,9 +108,14 @@ class AsyncTransport:
             "id": request_id,
         }
 
+        # Prepare headers, include X-Odoo-Database if database is specified
+        headers = {}
+        if database:
+            headers["X-Odoo-Database"] = database
+
         try:
-            # Make the HTTP request
-            response = await self._client.post("/jsonrpc", json=payload)
+            # Make the HTTP request (with database header for Odoo 19+)
+            response = await self._client.post("/jsonrpc", json=payload, headers=headers)
             response.raise_for_status()
 
             # Parse JSON response

--- a/src/zenoo_rpc/transport/session.py
+++ b/src/zenoo_rpc/transport/session.py
@@ -93,13 +93,17 @@ class SessionManager:
             AuthenticationError: If authentication fails
         """
         try:
-            # First, get server version info
-            version_result = await transport.json_rpc_call("common", "version", {})
+            # First, get server version info (with database header for Odoo 19+)
+            version_result = await transport.json_rpc_call(
+                "common", "version", {}, database=database
+            )
             self._server_version = version_result.get("result", {})
 
-            # Authenticate user
+            # Authenticate user (with database header for Odoo 19+)
             auth_result = await transport.json_rpc_call(
-                "common", "authenticate", {"args": [database, username, password, {}]}
+                "common", "authenticate",
+                {"args": [database, username, password, {}]},
+                database=database
             )
 
             uid = auth_result.get("result")
@@ -143,14 +147,18 @@ class SessionManager:
         # Note: API key authentication might require different implementation
         # depending on Odoo version and configuration
         try:
-            # Get server version info
-            version_result = await transport.json_rpc_call("common", "version", {})
+            # Get server version info (with database header for Odoo 19+)
+            version_result = await transport.json_rpc_call(
+                "common", "version", {}, database=database
+            )
             self._server_version = version_result.get("result", {})
 
             # For API key authentication, we might need to use a different approach
-            # This is a placeholder implementation
+            # This is a placeholder implementation (with database header for Odoo 19+)
             auth_result = await transport.json_rpc_call(
-                "common", "authenticate", {"args": [database, username, api_key, {}]}
+                "common", "authenticate",
+                {"args": [database, username, api_key, {}]},
+                database=database
             )
 
             uid = auth_result.get("result")


### PR DESCRIPTION
## Summary
- Add `database` parameter to `json_rpc_call` method
- Include `X-Odoo-Database` header in HTTP requests when database is specified
- Required for Odoo 19+ compatibility where database header is mandatory

## Changes
- `client.py`: Pass database to transport calls
- `httpx_transport.py`: Accept database parameter and set header
- `session.py`: Pass database to all authentication calls

## Additional fixes
- Python <3.10 compatibility: Use `Set[str]` instead of `set[str]`
- Add `__future__.annotations` imports for forward references

## Testing
Tested with Odoo 18 and prepared for Odoo 19+ based on Odoo roadmap.