### PR TITLE
fix: resolve MCP server write failures

### DIFF
--- a/src/zenoo_rpc/mcp_server/server.py
+++ b/src/zenoo_rpc/mcp_server/server.py
@@ -212,6 +212,7 @@ Rate Limits: {self.config.security.rate_limit_requests} requests per {self.confi
                 self.config.odoo_username,
                 self.config.odoo_password
             )
+            await self.zenoo_client.setup_transaction_manager()
             logger.info("Connected to Odoo successfully")
         except Exception as e:
             logger.error(f"Failed to connect to Odoo: {e}")


### PR DESCRIPTION
## Problem

Two bugs prevent MCP write operations from working when using the HTTP 
proxy with clients like Letta.

### Bug: `setup_transaction_manager()` never called on startup

Any write tool (`create_record`, `update_record`, `delete_record`) fails 
immediately with:
```
Transaction manager not initialized. Call setup_transaction_manager() first.
```

`_connect_to_odoo()` in `mcp_server/server.py` calls `login()` but never 
calls `setup_transaction_manager()` on the `ZenooClient`. Ironically, the 
comments inside `_handle_create_record` and siblings already say 
*"transactions require setup_transaction_manager() to be called first"* — 
the wiring at startup was simply missing.

**Fix:** Add one line after `login()` in `_connect_to_odoo()`:
```python
await self.zenoo_client.setup_transaction_manager()
```

---